### PR TITLE
fix: Make markdown_content and task_order optional in UpdateHopeRequest

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,8 +54,8 @@ class HopeRequest(BaseModel):
 class UpdateHopeRequest(BaseModel):
     name: str
     parent_name: Optional[str] = None
-    markdown_content: str
-    task_order: str
+    markdown_content: Optional[str] = None
+    task_order: Optional[str] = None
 
 class ColumnRequest(BaseModel):
     key: str


### PR DESCRIPTION
 Updated the UpdateHopeRequest model to allow `markdown_content` and `task_order` fields to be
 optional, aligning with potential use cases where these fields may not be required.