### PR TITLE
feat: Refactor Hope entity to use 'key' as identifier

### DIFF
--- a/models.py
+++ b/models.py
@@ -7,9 +7,10 @@ class Hope(Base):
     __tablename__ = 'hopes'
 
     id = Column(Integer, primary_key=True, index=True)
+    key = Column(String)
     name = Column(String)
     markdown_content = Column(String)
-    parent_name = Column(String, nullable=True) 
+    parent_key = Column(String, nullable=True) 
     task_order = Column(Text)
 
 class Task(Base):


### PR DESCRIPTION
 - Replace 'name' with 'key' as the primary identifier for Hope entities.
 - Add new endpoint to delete Hope by 'key'.
 - Update existing endpoints to operate based on 'key' instead of 'name'.
 - Adjust 'UpdateHopeRequest' model to allow optional 'name' updates.
 - Include 'parent_key' in HopeRequest and UpdateHopeRequest models.
 - Modify database model to include 'key' and 'parent_key' fields.
 - Ensure backward compatibility by retaining 'name' in the Hope model.