### PR TITLE
fix: Handle empty parent_key in update_hope_by_key

### DIFF
--- a/main.py
+++ b/main.py
@@ -221,13 +221,14 @@ async def delete_hope_by_key(db: db_dependency, key: str):
 
 @app.put("/hopes", status_code=status.HTTP_204_NO_CONTENT)
 async def update_hope_by_key(db: db_dependency, hope_request: UpdateHopeRequest):
+    print('hope_request', hope_request)
     hope = db.query(Hope).filter(Hope.key == hope_request.key).first()
     if hope is None:
         raise HTTPException(status_code=404, detail="Hope not found")
     if hope_request.name is not None:
         hope.name = hope_request.name
     if hope_request.parent_key is not None:
-        hope.parent_key = hope_request.parent_key
+        hope.parent_key = hope_request.parent_key if hope_request.parent_key != '' else None
     if hope_request.markdown_content is not None:
         hope.markdown_content = hope_request.markdown_content
     if hope_request.task_order is not None:


### PR DESCRIPTION
 A check has been added in the update_hope_by_key function to ensure that an empty string for the
 parent_key is converted to None. This prevents the assignment of an empty string to the parent_key fiel
 in the database, adhering to the expected data integrity.